### PR TITLE
Note that directory artifacts must be zipped.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Usage
     *  a.) Navigate to your Jenkins project of choice and select *Configure* from the menu.
     *  b.) Click on the *Add post-build action* button and select *Run Tests on AppThwack*.
     *  c.) Select your AppThwack project and devicepool from the respective dropdowns.
-    *  d.) Enter file pattern for finding your Application build artifact.
+    *  d.) Enter file pattern for finding your Application build artifact. If the artifacat is a directory, such as a `.app` or `.xctest` artifact, it must be zipped, first.
     *  e.) Select the test type you wish to use and configure it as necessary.
     *  f.) Once you're ready, hit *Save*.
 


### PR DESCRIPTION
Consider putting in an example. I have an "Execute shell" build step that looks like this:

    mkdir -p AppThwack
    ditto -ck --keepParent --norsrc build/Debug-iphoneos/MyApp.app AppThwack/MyApp.zip
    ditto -ck --keepParent --norsrc build/Debug-iphoneos/MyTests.xctest AppThwack/MyTestsTests.zip

And then the artifacts are identified as `AppThwack/MyApp.zip` and, for the tests, `AppThwack/MyTestsTests.zip`.